### PR TITLE
Board Bug Fix

### DIFF
--- a/TicTacToe/src/main/java/TechnicolorTales/Board.java
+++ b/TicTacToe/src/main/java/TechnicolorTales/Board.java
@@ -59,7 +59,7 @@ public class Board {
             return true;
 
         // Diagonale von (0,2) bis (2,0)
-        if (this.cells[0][2] != ' ' && this.cells[0][2] == this.cells[1][1] && this.cells[0][0] == this.cells[2][0])
+        if (this.cells[0][2] != ' ' && this.cells[0][2] == this.cells[1][1] && this.cells[0][2] == this.cells[2][0])
             return true;
 
         return false;


### PR DESCRIPTION
The hasWinner method was checking the diagonals from (0,2) to (2,0) incorrectly. The code is now corrected and the Winner of the game is therefore selected correctly. 